### PR TITLE
SA-610: filtro em cascata dos campos do PPA

### DIFF
--- a/src/app/shared/components/properties/type-property/property-group/property-group.component.html
+++ b/src/app/shared/components/properties/type-property/property-group/property-group.component.html
@@ -19,7 +19,7 @@
         (changed)="changed.emit($event)">
       </app-property-integer>
       <app-property-selection *ngSwitchCase="types.SelectionModel" [property]="groupedProp"
-        (changed)="changed.emit($event)">
+        (changed)="onGroupedChanged(groupedProp, $event)">
       </app-property-selection>
       <app-property-textarea *ngSwitchCase="types.TextAreaModel" [property]="groupedProp"
         (changed)="changed.emit($event)">

--- a/src/app/shared/components/properties/type-property/property-group/property-group.component.ts
+++ b/src/app/shared/components/properties/type-property/property-group/property-group.component.ts
@@ -5,6 +5,13 @@ import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
 import {ConfigDataViewService} from "../../../../../shared/services/config-dataview.service";
 import {takeUntil} from "rxjs/operators";
 import {Subject} from "rxjs";
+import {
+  detectPpaWiring,
+  filterDependentOptions,
+  IPpaWiring,
+  masterOptions,
+  selectedProgramCodes
+} from 'src/app/shared/utils/ppa-relationship.util';
 
 @Component({
   selector: 'app-property-group',
@@ -19,6 +26,7 @@ export class PropertyGroupComponent implements OnInit {
   types = TypePropertyModelEnum;
   responsive: boolean;
   $destroy = new Subject();
+  ppaWiring: IPpaWiring;
 
   constructor(
     private responsiveSrv: ResponsiveService,
@@ -30,6 +38,39 @@ export class PropertyGroupComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.ppaWiring = detectPpaWiring(this.groupProperty);
+    if (this.ppaWiring) {
+      [this.ppaWiring.source, ...this.ppaWiring.dependents].forEach(property => {
+        if (!property.allPossibleValues) {
+          property.allPossibleValues = property.possibleValues;
+        }
+      });
+      // Roda antes do ngOnInit dos filhos, então os selects já nascem filtrados.
+      // Sem podar valores: abrir a tela não pode marcar o formulário como alterado.
+      this.applyPpaFilter(false);
+    }
+  }
+
+  onGroupedChanged(groupedProperty: PropertyTemplateModel, event: any) {
+    if (this.ppaWiring && groupedProperty === this.ppaWiring.source) {
+      this.applyPpaFilter(true);
+    }
+    this.changed.emit(event);
+  }
+
+  applyPpaFilter(prune: boolean) {
+    const codes = selectedProgramCodes(this.ppaWiring.source);
+    this.ppaWiring.dependents.forEach(dependent => {
+      // Nova referência: o p-multiSelect só reprocessa [options] quando o array troca.
+      dependent.possibleValues = filterDependentOptions(masterOptions(dependent), codes);
+      if (prune && Array.isArray(dependent.value)) {
+        const allowed = new Set(dependent.possibleValues.map(option => option.value));
+        const kept = (dependent.value as string[]).filter(value => allowed.has(value));
+        if (kept.length !== (dependent.value as string[]).length) {
+          dependent.value = kept;
+        }
+      }
+    });
   }
 
 }

--- a/src/app/shared/models/PropertyTemplateModel.ts
+++ b/src/app/shared/models/PropertyTemplateModel.ts
@@ -23,6 +23,8 @@ export class PropertyTemplateModel implements IProperty {
   max?: number;
   precision?: number;
   possibleValues?: { label: string; value: string }[];
+  // Lista mestre, preservada enquanto possibleValues é filtrado em cascata (grupo do PPA).
+  allPossibleValues?: { label: string; value: string }[];
   possibleValuesIds?: { label: string; value: number }[];
   multipleSelection?: boolean;
   rows?: number;

--- a/src/app/shared/services/workpack-property.service.ts
+++ b/src/app/shared/services/workpack-property.service.ts
@@ -126,6 +126,7 @@ export class WorkpackPropertyService {
     property.max = pro.max;
     property.precision = pro.precision;
     property.possibleValues = pro.possibleValues;
+    property.allPossibleValues = pro.allPossibleValues;
     property.possibleValuesIds = pro.possibleValuesIds;
     property.multipleSelection = pro.multipleSelection;
     property.rows = pro.rows;

--- a/src/app/shared/utils/ppa-relationship.util.spec.ts
+++ b/src/app/shared/utils/ppa-relationship.util.spec.ts
@@ -1,0 +1,140 @@
+import { TypePropertyModelEnum } from '../enums/TypePropertyModelEnum';
+import { PropertyTemplateModel } from '../models/PropertyTemplateModel';
+import {
+  classifyPpaProperty,
+  detectPpaWiring,
+  filterDependentOptions,
+  programCodeFromLabel,
+  selectedProgramCodes
+} from './ppa-relationship.util';
+
+const option = (label: string) => ({ label, value: label });
+
+const selection = (labels: string[], value?: string[]): PropertyTemplateModel => {
+  const property = new PropertyTemplateModel();
+  property.type = TypePropertyModelEnum.SelectionModel;
+  property.multipleSelection = true;
+  property.possibleValues = labels.map(option);
+  property.value = value;
+  return property;
+};
+
+const PROGRAMS = ['Programa 5001 - Gestao Dinamica e Eficiente', 'Programa 5007 - Saude Integral'];
+const INDICATORS = ['Indicador 5001 - Empresas parceiras', 'Indicador 5007 - Cobertura da atencao basica'];
+const ACTIONS = ['Acao 1640 - 5001 - Educacao Fiscal', 'Acao 4255 - 5007 - Capacitacao'];
+
+describe('ppa-relationship.util', () => {
+
+  describe('programCodeFromLabel', () => {
+    it('extrai o código do programa nos três formatos do PPA', () => {
+      expect(programCodeFromLabel(PROGRAMS[0])).toBe('5001');
+      expect(programCodeFromLabel(INDICATORS[0])).toBe('5001');
+      expect(programCodeFromLabel(ACTIONS[0])).toBe('5001');
+    });
+
+    it('usa o segundo número da ação, não o código da própria ação', () => {
+      expect(programCodeFromLabel('Acao 1640 - 5001 - Educacao Fiscal')).toBe('5001');
+    });
+
+    it('devolve null para labels fora do padrão', () => {
+      expect(programCodeFromLabel('Concluído')).toBeNull();
+      expect(programCodeFromLabel('')).toBeNull();
+      expect(programCodeFromLabel(null)).toBeNull();
+    });
+  });
+
+  describe('classifyPpaProperty', () => {
+    it('classifica programa como source e indicador/ação como dependent', () => {
+      expect(classifyPpaProperty(selection(PROGRAMS))).toBe('source');
+      expect(classifyPpaProperty(selection(INDICATORS))).toBe('dependent');
+      expect(classifyPpaProperty(selection(ACTIONS))).toBe('dependent');
+    });
+
+    it('ignora selects que não são do PPA', () => {
+      expect(classifyPpaProperty(selection(['Concluído', 'Cancelado']))).toBeNull();
+    });
+
+    it('ignora quando apenas parte das opções casa o padrão', () => {
+      expect(classifyPpaProperty(selection([PROGRAMS[0], 'Outro qualquer']))).toBeNull();
+    });
+
+    it('ignora propriedades que não são SelectionModel', () => {
+      const property = selection(PROGRAMS);
+      property.type = TypePropertyModelEnum.TextModel;
+      expect(classifyPpaProperty(property)).toBeNull();
+    });
+
+    it('classifica a partir da lista mestre quando possibleValues já está filtrado', () => {
+      const property = selection([]);
+      property.allPossibleValues = INDICATORS.map(option);
+      expect(classifyPpaProperty(property)).toBe('dependent');
+    });
+  });
+
+  describe('detectPpaWiring', () => {
+    it('reconhece o grupo do PPA', () => {
+      const group = new PropertyTemplateModel();
+      group.groupedProperties = [selection(PROGRAMS), selection(ACTIONS), selection(INDICATORS)];
+      const wiring = detectPpaWiring(group);
+      expect(wiring).toBeTruthy();
+      expect(wiring.source).toBe(group.groupedProperties[0]);
+      expect(wiring.dependents.length).toBe(2);
+    });
+
+    it('devolve null quando não há programa no grupo', () => {
+      const group = new PropertyTemplateModel();
+      group.groupedProperties = [selection(INDICATORS)];
+      expect(detectPpaWiring(group)).toBeNull();
+    });
+
+    it('devolve null quando não há dependentes', () => {
+      const group = new PropertyTemplateModel();
+      group.groupedProperties = [selection(PROGRAMS)];
+      expect(detectPpaWiring(group)).toBeNull();
+    });
+
+    it('devolve null para um grupo sem propriedades', () => {
+      expect(detectPpaWiring(new PropertyTemplateModel())).toBeNull();
+    });
+  });
+
+  describe('selectedProgramCodes', () => {
+    it('reúne os códigos de todos os programas selecionados', () => {
+      const codes = selectedProgramCodes(selection(PROGRAMS, PROGRAMS));
+      expect(Array.from(codes).sort()).toEqual(['5001', '5007']);
+    });
+
+    it('devolve conjunto vazio quando nada está selecionado', () => {
+      expect(selectedProgramCodes(selection(PROGRAMS)).size).toBe(0);
+      expect(selectedProgramCodes(selection(PROGRAMS, [])).size).toBe(0);
+    });
+  });
+
+  describe('filterDependentOptions', () => {
+    const all = [...INDICATORS].map(option);
+
+    it('mantém a lista completa quando nenhum programa está selecionado', () => {
+      const result = filterDependentOptions(all, new Set<string>());
+      expect(result.length).toBe(2);
+      expect(result).not.toBe(all);
+    });
+
+    it('filtra pelo programa selecionado', () => {
+      const result = filterDependentOptions(all, new Set(['5001']));
+      expect(result.map(o => o.label)).toEqual([INDICATORS[0]]);
+    });
+
+    it('faz a união quando há mais de um programa selecionado', () => {
+      expect(filterDependentOptions(all, new Set(['5001', '5007'])).length).toBe(2);
+    });
+
+    it('devolve lista vazia para um programa sem itens', () => {
+      expect(filterDependentOptions(all, new Set(['5046']))).toEqual([]);
+    });
+
+    it('sempre devolve uma nova referência de array', () => {
+      expect(filterDependentOptions(all, new Set(['5001']))).not.toBe(all);
+    });
+  });
+
+});

--- a/src/app/shared/utils/ppa-relationship.util.ts
+++ b/src/app/shared/utils/ppa-relationship.util.ts
@@ -1,0 +1,99 @@
+import { TypePropertyModelEnum } from '../enums/TypePropertyModelEnum';
+import { PropertyTemplateModel } from '../models/PropertyTemplateModel';
+
+/**
+ * Filtro em cascata do grupo "Relação com o PPA": o código do programa está embutido
+ * no label de todo item, então Indicadores e Ação podem ser filtrados pelo Programa
+ * selecionado sem nenhuma consulta adicional.
+ *
+ *   Programa 5001 - Gestao Dinamica e Eficiente
+ *   Indicador 5001 - Empresas parceiras
+ *   Acao 1640 - 5001 - Educacao Fiscal
+ */
+const PROGRAM_RE = /^Programa\s+(\d+)\b/;
+const INDICATOR_RE = /^Indicador\s+(\d+)\b/;
+const ACTION_RE = /^Acao\s+\d+\s*-\s*(\d+)\b/;
+
+export type PpaRole = 'source' | 'dependent' | null;
+
+export interface IPpaOption {
+  label: string;
+  value: string;
+}
+
+export interface IPpaWiring {
+  source: PropertyTemplateModel;
+  dependents: PropertyTemplateModel[];
+}
+
+export const programCodeFromLabel = (label: string): string | null => {
+  if (!label) {
+    return null;
+  }
+  const match = PROGRAM_RE.exec(label) || INDICATOR_RE.exec(label) || ACTION_RE.exec(label);
+  return match ? match[1] : null;
+};
+
+const allMatch = (options: IPpaOption[], regex: RegExp): boolean =>
+  !!options && options.length > 0 && options.every(option => regex.test(option.label));
+
+export const masterOptions = (property: PropertyTemplateModel): IPpaOption[] =>
+  (property.allPossibleValues || property.possibleValues || []) as IPpaOption[];
+
+export const classifyPpaProperty = (property: PropertyTemplateModel): PpaRole => {
+  if (!property || property.type !== TypePropertyModelEnum.SelectionModel) {
+    return null;
+  }
+  const options = masterOptions(property);
+  if (allMatch(options, PROGRAM_RE)) {
+    return 'source';
+  }
+  if (allMatch(options, INDICATOR_RE) || allMatch(options, ACTION_RE)) {
+    return 'dependent';
+  }
+  return null;
+};
+
+/**
+ * Reconhece o grupo pelos prefixos dos labels, não por id ou nome de propriedade.
+ * Se os dados do PPA mudarem de formato, devolve null e o formulário volta ao
+ * comportamento sem filtro.
+ */
+export const detectPpaWiring = (group: PropertyTemplateModel): IPpaWiring | null => {
+  const properties = (group && group.groupedProperties) || [];
+  let source: PropertyTemplateModel = null;
+  const dependents: PropertyTemplateModel[] = [];
+  properties.forEach(property => {
+    const role = classifyPpaProperty(property);
+    if (role === 'source') {
+      source = property;
+    } else if (role === 'dependent') {
+      dependents.push(property);
+    }
+  });
+  return source && dependents.length > 0 ? { source, dependents } : null;
+};
+
+export const selectedProgramCodes = (source: PropertyTemplateModel): Set<string> => {
+  const value = source && source.value;
+  const selected: string[] = Array.isArray(value) ? value as string[] : (value ? [value as string] : []);
+  const codes = new Set<string>();
+  selected.forEach(item => {
+    const code = programCodeFromLabel(item);
+    if (code) {
+      codes.add(code);
+    }
+  });
+  return codes;
+};
+
+/** Sem programa selecionado, mantém a lista completa. */
+export const filterDependentOptions = (all: IPpaOption[], codes: Set<string>): IPpaOption[] => {
+  if (codes.size === 0) {
+    return (all || []).slice();
+  }
+  return (all || []).filter(option => {
+    const code = programCodeFromLabel(option.label);
+    return code !== null && codes.has(code);
+  });
+};


### PR DESCRIPTION
## Objetivo

No grupo de propriedades **"Relação com o PPA"** (WorkpackModel "Projeto Estratégico"), ao selecionar o(s) programa(s), os selects **Indicadores** e **Ação** passam a listar apenas os itens do(s) programa(s) escolhido(s), em vez de mostrarem todos os 223 indicadores e 683 ações de todos os programas.

Exemplo: ao selecionar `Programa 5001 - Gestão Dinâmica e Eficiente`, Indicadores passa a mostrar só os `Indicador 5001 - ...` e Ação só os `Acao ... - 5001 - ...`.

## Como funciona

O código do programa já está embutido no label de todo item (`Acao 1640 - **5001** - ...`, `Indicador **5001** - ...`), então a cascata é derivada dos dados que já estão no banco — **sem mudança de backend, schema ou seed**.

- A lógica vive no `PropertyGroupComponent`, único componente que enxerga os três selects irmãos juntos, apoiada por funções puras em `ppa-relationship.util.ts`.
- O grupo é reconhecido pelos **prefixos dos labels** das opções, não por id do Neo4j nem por nome de propriedade. Se o formato dos dados mudar, a detecção retorna `null` e o formulário volta ao comportamento atual (degradação segura).
- A lista completa é preservada em `allPossibleValues`, para não ser perdida quando `possibleValues` é filtrado (evita restaurar a lista curta ao cancelar alterações).

## Comportamento

- **Sem programa selecionado:** Indicadores e Ação mostram a lista completa.
- **Ao trocar/remover um programa:** indicadores/ações selecionados que ficaram órfãos são removidos automaticamente da seleção.
- Programa é multi-select: o filtro é a união dos códigos selecionados.

## Verificação

- `ng build --configuration=production` (AOT) passa — o binding do template e o componente integram no bundle de produção.
- Testes unitários do util (`ppa-relationship.util.spec.ts`): **19/19** em Chrome headless — extração do código nos três formatos, detecção do grupo, união de programas, filtragem, poda de órfãos e degradação segura para grupos não-PPA.
- Lógica validada contra os 928 itens reais do PPA (contagens por programa conferidas).

## Arquivos

- `shared/utils/ppa-relationship.util.ts` (novo) + spec
- `shared/components/properties/type-property/property-group/property-group.component.{ts,html}`
- `shared/models/PropertyTemplateModel.ts` (campo `allPossibleValues`)
- `shared/services/workpack-property.service.ts` (cópia do campo no backup)