### PR TITLE
SA-633: envia key ao cadastrar pessoa nova nas permissões de escritório e plano

### DIFF
--- a/src/app/modules/office/office-permissions/office-permissions.component.ts
+++ b/src/app/modules/office/office-permissions/office-permissions.component.ts
@@ -341,6 +341,7 @@ export class OfficePermissionsComponent implements OnInit, OnDestroy {
         this.person = {
           name,
           email: this.searchedEmailPerson,
+          key: this.searchedEmailPerson,
           roles: [{ role: 'citizen' }],
         };
       }

--- a/src/app/modules/plan/plan-permissions/plan-permissions.component.ts
+++ b/src/app/modules/plan/plan-permissions/plan-permissions.component.ts
@@ -371,6 +371,7 @@ export class PlanPermissionsComponent implements OnInit, OnDestroy {
           name,
           fullName: name,
           email: this.searchedEmailPerson,
+          key: this.searchedEmailPerson,
           roles: [ {role: 'citizen'} ]
         };
       }


### PR DESCRIPTION
## Problema

Não é possível salvar a permissão de um usuário novo (que ainda não existe no OpenPMO) nas telas de permissão de **Escritório** e **Plano**.

## Causa

Quando o provedor de identidade não é o Acesso Cidadão, a busca de pessoa é feita por e-mail. Se a pessoa não existe, o componente monta o objeto sem `key`:

- `office-permissions.component.ts:341`
- `plan-permissions.component.ts:370`

Mas o back exige `key`:

- `OfficePermissionParamDto.java:15` — `@NotNull private String key;`
- `PlanPermissionParamDto.java` — idem

Com `key: undefined`, o campo sai do JSON, o `@Valid` do controller rejeita e o POST volta **400** antes de `store()` rodar. Como é erro de validação tratado, não aparece stacktrace no log — o sintoma é a tela travar no spinner sem mensagem clara.

## Correção

Usa o e-mail como `key`, exatamente o tratamento já aplicado em `administrator.component.ts` nos commits a9d852e ("add key a nova pessoa") e 7b9b869 ("add key ao novo admin"). Aquele fix cobriu só a tela de Administradores; estas duas ficaram de fora.

O back já trata `key == e-mail` em `PersonService.maybeFindPersonDataByKey` e no `SecurityFilter`.

## Teste

Escritório e Plano → adicionar permissão → buscar e-mail inexistente → preencher papéis → salvar.